### PR TITLE
Add laser game logic, assets, and tests

### DIFF
--- a/laser_game/README.md
+++ b/laser_game/README.md
@@ -1,0 +1,114 @@
+# Laser Game
+
+Ein modernes Laser-Puzzlespiel mit reflektierenden Spiegeln, aufteilenden Prismen und energiehungrigen Feldern. Dieses Paket bündelt die Spiellogik, Leveldaten, Assets und Tests, sodass du sofort mit dem Bauen einer Desktop- oder Web-Variante starten kannst.
+
+![Modernes UI-Mockup](assets/screenshots/modern_ui_mockup.svg)
+
+## Inhalt
+
+- `game.py`: Kernlogik für Laserphysik, Levelverwaltung und Lösungskontrolle.
+- `levels/`: JSON-Dateien mit Levelgeometrie, Metadaten und Spezialobjekten.
+- `solutions/`: Automatisiert prüfbare Mustersolutions pro Level.
+- `assets/`: SVG-Sprites für Raster, Spiegel, Ziele, UI und Mockups.
+- `tests/`: Unit- und Integrationstests für Spiegelverhalten, Levelabschluss und Solution-Validierung.
+- `demo.py`: Konsolen-Demo, die ein Level lädt, eine Mustersolution anwendet und die Ergebnisse der Simulation ausgibt.
+
+## Voraussetzungen & Installation
+
+Das Projekt benötigt Python 3.10 oder höher. Optional kannst du `pygame` installieren, falls du auf Basis dieser Logik eine UI entwickeln möchtest.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install pytest pygame
+```
+
+## Ausführung
+
+Starte die Konsolen-Demo, um das Laser-System mit der Mustersolution des Einstiegslevels zu simulieren:
+
+```bash
+python -m laser_game.demo
+```
+
+Die Demo lädt `level_intro`, wendet die hinterlegte Mustersolution an und gibt die Energieverteilung sowie die simulierten Strahlsegmente aus. Diese Ausgabe eignet sich hervorragend als Basis für Debugging, Telemetrie oder UI-Overlays.
+
+## Steuerungskonzept für eine UI
+
+Die Logik ist so aufgebaut, dass ein modernes Interface (z. B. mit Pygame, pyglet oder einer WebCanvas-Engine) lediglich folgende Interaktionen abbilden muss:
+
+1. **Level-Auswahl** über die Metadaten (`name`, `difficulty`).
+2. **Platzierung von Elementen**: Mirrors, Prismen und Energiefelder werden als Platzierungen mit Position, Typ und Parameter (`orientation`, `spread`, `drain`) injiziert.
+3. **Simulation auslösen** mittels `LaserGame.propagate()` und Visualisierung der zurückgegebenen Strahlsegmente (`BeamSegment`).
+4. **Erfolgsprüfung** via `LaserGame.level_complete()` bzw. `SolutionValidator.validate()` für Mustersolutions oder Nutzerlösungen.
+
+## Level-Format
+
+Jede Leveldatei ist eine JSON-Struktur mit folgenden Feldern:
+
+```json
+{
+  "name": "Intro Reflect",
+  "difficulty": "Easy",
+  "width": 6,
+  "height": 6,
+  "emitters": [
+    {"position": [0, 3], "direction": "EAST", "energy": 10}
+  ],
+  "targets": [
+    {"position": [4, 1], "required_energy": 1, "label": "North Node"}
+  ],
+  "mirrors": [
+    {"position": [3, 3], "orientation": "/"}
+  ],
+  "prisms": [
+    {"position": [3, 4], "spread": 1}
+  ],
+  "energy_fields": [
+    {"position": [5, 4], "drain": 1, "color": "magenta"}
+  ]
+}
+```
+
+- **Positionen** werden im Raster (x, y) angegeben, beginnend bei `(0, 0)` in der oberen linken Ecke.
+- **Emitter** definieren Startposition, Ausrichtung (`NORTH`, `EAST`, `SOUTH`, `WEST`) und die Energiereserve.
+- **Targets** geben an, wie viele Energieeinheiten das Ziel absorbieren muss.
+- **Mirrors** nutzen `"/"` oder `"\\"` zur Orientierung.
+- **Prisms** erzeugen aus einem Strahl mehrere (vorwärts, links, rechts).
+- **Energy Fields** ziehen pro Durchgang `drain` Einheiten ab; ist die Energie aufgebraucht, stoppt der Strahl.
+
+## Mustersolutions
+
+Für jedes Level existiert eine JSON-Datei in `solutions/`, die zusätzliche Platzierungen sowie erwartete Zielenergien beschreibt. Beispiel (`solutions/level_intro.json`):
+
+```json
+{
+  "placements": [
+    {"type": "mirror", "position": [3, 3], "orientation": "/"},
+    {"type": "mirror", "position": [3, 1], "orientation": "/"}
+  ],
+  "expected_targets": {
+    "(4, 1)": 1
+  }
+}
+```
+
+Die `SolutionValidator`-Klasse wendet diese Platzierungen an, simuliert die Laser-Physik und vergleicht die gemessenen Zielenergien mit den erwarteten Werten. So lässt sich jede neue Level- oder Gameplay-Änderung sofort validieren.
+
+## Tests
+
+Die Tests decken Spiegelreflexionen, Levelabschlüsse und Solution-Validierung ab und können mit Pytest ausgeführt werden:
+
+```bash
+pytest laser_game/tests
+```
+
+Die Integrationstests laden die echten Level- und Solution-Dateien und sichern so das Zusammenspiel der JSON-Daten mit der Kernlogik.
+
+## Weiterentwicklung
+
+- **UI-Integration**: Kopple `LaserGame.playthrough()` mit einer Pygame-Loop, die Sprites aus `assets/` zeichnet und Interaktionen entgegennimmt.
+- **Level-Editor**: Erstelle ein Tool, das Rasterobjekte per Drag & Drop setzt und direkt JSON plus Mustersolution exportiert.
+- **Analytics**: Nutze die Strahlsegmente (`BeamSegment`) für Heatmaps oder Wiederholungen.
+
+Viel Spaß beim Experimentieren mit Licht, Spiegeln und Energie!

--- a/laser_game/__init__.py
+++ b/laser_game/__init__.py
@@ -1,0 +1,10 @@
+"""Laser Game package."""
+
+from .game import LaserGame, Level, LevelLoader, SolutionValidator
+
+__all__ = [
+    "LaserGame",
+    "Level",
+    "LevelLoader",
+    "SolutionValidator",
+]

--- a/laser_game/assets/board_tile.svg
+++ b/laser_game/assets/board_tile.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gridGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#111827" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="18" fill="url(#gridGradient)" />
+  <path d="M16 64h96M64 16v96" stroke="#3b82f6" stroke-width="4" stroke-linecap="round" opacity="0.4" />
+  <circle cx="64" cy="64" r="8" fill="#60a5fa" opacity="0.6" />
+</svg>

--- a/laser_game/assets/goal.svg
+++ b/laser_game/assets/goal.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <radialGradient id="goalGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fef08a" />
+      <stop offset="100%" stop-color="#f97316" />
+    </radialGradient>
+  </defs>
+  <circle cx="64" cy="64" r="56" fill="#1e1b4b" />
+  <circle cx="64" cy="64" r="40" fill="url(#goalGlow)" opacity="0.85" />
+  <circle cx="64" cy="64" r="16" fill="#fde047" stroke="#facc15" stroke-width="4" />
+  <path d="M64 36 L72 56 L94 56 L76 70 L84 92 L64 78 L44 92 L52 70 L34 56 L56 56 Z"
+        fill="#1f2937" opacity="0.3" />
+</svg>

--- a/laser_game/assets/mirror.svg
+++ b/laser_game/assets/mirror.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="mirrorGlass" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f9fafb" />
+      <stop offset="100%" stop-color="#cbd5f5" />
+    </linearGradient>
+  </defs>
+  <rect x="20" y="20" width="88" height="88" rx="14" fill="#0f172a" />
+  <polygon points="24,104 104,24 104,48 48,104" fill="url(#mirrorGlass)" opacity="0.9" />
+  <line x1="32" y1="96" x2="96" y2="32" stroke="#93c5fd" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/laser_game/assets/screenshots/modern_ui_mockup.svg
+++ b/laser_game/assets/screenshots/modern_ui_mockup.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="laser" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bg)" />
+  <rect x="120" y="80" width="720" height="560" rx="48" fill="#111827" opacity="0.85" />
+  <g transform="translate(220 140)">
+    <rect width="520" height="400" rx="36" fill="#0b1120" stroke="#1f2937" stroke-width="4" />
+    <g fill="none" stroke="#1e3a8a" stroke-width="2" opacity="0.4">
+      <path d="M40 0v400M120 0v400M200 0v400M280 0v400M360 0v400M440 0v400" />
+      <path d="M0 40h520M0 120h520M0 200h520M0 280h520M0 360h520" />
+    </g>
+    <path d="M40 320 L200 320" stroke="url(#laser)" stroke-width="12" stroke-linecap="round" />
+    <path d="M200 320 L200 160" stroke="url(#laser)" stroke-width="12" stroke-linecap="round" />
+    <path d="M200 160 L360 160" stroke="url(#laser)" stroke-width="12" stroke-linecap="round" />
+    <circle cx="360" cy="160" r="28" fill="#facc15" />
+    <rect x="180" y="300" width="40" height="40" rx="8" fill="#f8fafc" opacity="0.8" />
+    <rect x="180" y="140" width="40" height="40" rx="8" fill="#f8fafc" opacity="0.8" />
+  </g>
+  <g transform="translate(920 120)">
+    <rect width="220" height="120" rx="24" fill="#1e293b" opacity="0.9" />
+    <text x="110" y="60" font-family="'Inter', sans-serif" font-weight="600" font-size="36" fill="#f8fafc" text-anchor="middle">
+      Intro Reflect
+    </text>
+    <text x="110" y="90" font-family="'Inter', sans-serif" font-size="20" fill="#94a3b8" text-anchor="middle">
+      Difficulty: Easy
+    </text>
+  </g>
+  <g transform="translate(920 280)">
+    <rect width="220" height="180" rx="28" fill="#0f172a" opacity="0.9" />
+    <text x="110" y="56" font-family="'Inter', sans-serif" font-size="24" fill="#f8fafc" text-anchor="middle">
+      Target Status
+    </text>
+    <text x="110" y="100" font-family="'Inter', sans-serif" font-size="18" fill="#38bdf8" text-anchor="middle">
+      North Node: 1 / 1
+    </text>
+    <text x="110" y="136" font-family="'Inter', sans-serif" font-size="18" fill="#38bdf8" text-anchor="middle">
+      Beam Integrity: 72%
+    </text>
+  </g>
+  <g transform="translate(920 520)">
+    <rect width="220" height="120" rx="28" fill="#0e7490" />
+    <text x="110" y="72" font-family="'Inter', sans-serif" font-size="28" fill="#ecfeff" text-anchor="middle">
+      Fire Laser
+    </text>
+  </g>
+</svg>

--- a/laser_game/assets/ui_button.svg
+++ b/laser_game/assets/ui_button.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 64">
+  <defs>
+    <linearGradient id="buttonGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#14b8a6" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="192" height="56" rx="18" fill="#0f172a" />
+  <rect x="8" y="8" width="184" height="48" rx="16" fill="url(#buttonGradient)" />
+  <text x="100" y="38" font-family="'Segoe UI', 'Inter', sans-serif" font-size="22" fill="#f8fafc" text-anchor="middle">
+    FIRE LASER
+  </text>
+</svg>

--- a/laser_game/demo.py
+++ b/laser_game/demo.py
@@ -1,0 +1,32 @@
+"""Simple command line demo for the laser game logic."""
+
+from pathlib import Path
+
+from .game import LaserGame, LevelLoader, SolutionValidator
+
+
+def main() -> None:
+    package_root = Path(__file__).resolve().parent
+    level_loader = LevelLoader(package_root / "levels")
+    solutions_root = package_root / "solutions"
+
+    level_name = "level_intro"
+    level = level_loader.load(level_name)
+
+    validator = SolutionValidator(level_loader, solutions_root)
+    solution = validator.load_solution(level_name)
+    level = validator.apply_solution(level, solution)
+
+    game = LaserGame(level)
+    results = game.playthrough()
+
+    print("=== Laser Game Demo ===")
+    print(f"Level: {results['metadata']['name']} ({results['metadata']['difficulty']})")
+    print("Target energy deliveries:")
+    for target, energy in results["targets"].items():
+        print(f"  {target}: {energy}")
+    print(f"Beam segments simulated: {len(results['path'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/laser_game/game.py
+++ b/laser_game/game.py
@@ -1,0 +1,349 @@
+"""Core game logic for the laser puzzle experience."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+
+class Direction(Enum):
+    """Cardinal directions for the laser beam."""
+
+    NORTH = (0, -1)
+    EAST = (1, 0)
+    SOUTH = (0, 1)
+    WEST = (-1, 0)
+
+    @property
+    def vector(self) -> Tuple[int, int]:
+        return self.value
+
+    @staticmethod
+    def from_name(name: str) -> "Direction":
+        name = name.upper()
+        try:
+            return Direction[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown direction: {name}") from exc
+
+    def turn_left(self) -> "Direction":
+        mapping = {
+            Direction.NORTH: Direction.WEST,
+            Direction.WEST: Direction.SOUTH,
+            Direction.SOUTH: Direction.EAST,
+            Direction.EAST: Direction.NORTH,
+        }
+        return mapping[self]
+
+    def turn_right(self) -> "Direction":
+        mapping = {
+            Direction.NORTH: Direction.EAST,
+            Direction.EAST: Direction.SOUTH,
+            Direction.SOUTH: Direction.WEST,
+            Direction.WEST: Direction.NORTH,
+        }
+        return mapping[self]
+
+    def reverse(self) -> "Direction":
+        mapping = {
+            Direction.NORTH: Direction.SOUTH,
+            Direction.SOUTH: Direction.NORTH,
+            Direction.EAST: Direction.WEST,
+            Direction.WEST: Direction.EAST,
+        }
+        return mapping[self]
+
+
+@dataclass
+class Mirror:
+    """Reflects the laser depending on its orientation."""
+
+    orientation: str  # '/' or '\\'
+
+    def reflect(self, direction: Direction) -> Optional[Direction]:
+        if self.orientation == "/":
+            mapping = {
+                Direction.NORTH: Direction.EAST,
+                Direction.SOUTH: Direction.WEST,
+                Direction.EAST: Direction.NORTH,
+                Direction.WEST: Direction.SOUTH,
+            }
+        elif self.orientation == "\\":
+            mapping = {
+                Direction.NORTH: Direction.WEST,
+                Direction.SOUTH: Direction.EAST,
+                Direction.EAST: Direction.SOUTH,
+                Direction.WEST: Direction.NORTH,
+            }
+        else:
+            raise ValueError(f"Unknown mirror orientation: {self.orientation}")
+        return mapping.get(direction)
+
+
+@dataclass
+class Prism:
+    """Splits an incoming beam into multiple outputs."""
+
+    spread: int = 1
+
+    def split(self, direction: Direction) -> Sequence[Direction]:
+        # The primary beam continues forward, optional spread spawns left/right beams.
+        outputs = [direction]
+        if self.spread >= 1:
+            outputs.append(direction.turn_left())
+            outputs.append(direction.turn_right())
+        return outputs
+
+
+@dataclass
+class EnergyField:
+    """Consumes energy units from the beam that passes through."""
+
+    drain: int
+    color: str = "white"
+
+
+@dataclass
+class Target:
+    """Target that must receive sufficient energy to clear the level."""
+
+    required_energy: int = 1
+    label: str = ""
+
+
+@dataclass
+class LaserEmitter:
+    position: Tuple[int, int]
+    direction: Direction
+    energy: int = 10
+
+
+@dataclass
+class Level:
+    """In-memory representation of a level definition."""
+
+    name: str
+    difficulty: str
+    width: int
+    height: int
+    emitters: List[LaserEmitter] = field(default_factory=list)
+    mirrors: Dict[Tuple[int, int], Mirror] = field(default_factory=dict)
+    prisms: Dict[Tuple[int, int], Prism] = field(default_factory=dict)
+    energy_fields: Dict[Tuple[int, int], EnergyField] = field(default_factory=dict)
+    targets: Dict[Tuple[int, int], Target] = field(default_factory=dict)
+
+    @property
+    def metadata(self) -> Dict[str, str]:
+        return {
+            "name": self.name,
+            "difficulty": self.difficulty,
+            "dimensions": f"{self.width}x{self.height}",
+        }
+
+    def inside(self, position: Tuple[int, int]) -> bool:
+        x, y = position
+        return 0 <= x < self.width and 0 <= y < self.height
+
+
+@dataclass
+class BeamSegment:
+    start: Tuple[int, int]
+    end: Tuple[int, int]
+    direction: Direction
+
+
+class LevelLoader:
+    """Load level files stored as JSON."""
+
+    def __init__(self, root: Path):
+        self.root = Path(root)
+
+    def load(self, name: str) -> Level:
+        path = self.root / f"{name}.json"
+        if not path.exists():
+            raise FileNotFoundError(path)
+        data = json.loads(path.read_text())
+        return self._parse_level(data)
+
+    def _parse_level(self, data: Dict) -> Level:
+        level = Level(
+            name=data["name"],
+            difficulty=data.get("difficulty", "Unknown"),
+            width=data["width"],
+            height=data["height"],
+        )
+        for emitter in data.get("emitters", []):
+            level.emitters.append(
+                LaserEmitter(
+                    position=tuple(emitter["position"]),
+                    direction=Direction.from_name(emitter["direction"]),
+                    energy=emitter.get("energy", 10),
+                )
+            )
+        for mirror in data.get("mirrors", []):
+            position = tuple(mirror["position"])
+            level.mirrors[position] = Mirror(mirror.get("orientation", "/"))
+        for prism in data.get("prisms", []):
+            position = tuple(prism["position"])
+            level.prisms[position] = Prism(spread=prism.get("spread", 1))
+        for field in data.get("energy_fields", []):
+            position = tuple(field["position"])
+            level.energy_fields[position] = EnergyField(
+                drain=field.get("drain", 1),
+                color=field.get("color", "white"),
+            )
+        for target in data.get("targets", []):
+            position = tuple(target["position"])
+            level.targets[position] = Target(
+                required_energy=target.get("required_energy", 1),
+                label=target.get("label", ""),
+            )
+        return level
+
+
+class LaserGame:
+    """High level game manager handling laser propagation and win conditions."""
+
+    def __init__(self, level: Level):
+        self.level = level
+        self.reset()
+
+    def reset(self) -> None:
+        self.target_energy: Dict[Tuple[int, int], int] = {
+            position: 0 for position in self.level.targets
+        }
+        self.path: List[BeamSegment] = []
+
+    def propagate(self) -> None:
+        self.reset()
+        visited: Dict[Tuple[Tuple[int, int], Direction], int] = {}
+        queue: List[Tuple[Tuple[int, int], Direction, int]] = []
+        for emitter in self.level.emitters:
+            queue.append((emitter.position, emitter.direction, emitter.energy))
+
+        while queue:
+            position, direction, energy = queue.pop(0)
+            state_key = (position, direction)
+            if visited.get(state_key, -1) >= energy:
+                continue
+            visited[state_key] = energy
+
+            current = position
+            current_direction = direction
+            current_energy = energy
+
+            while current_energy > 0:
+                next_pos = (
+                    current[0] + current_direction.vector[0],
+                    current[1] + current_direction.vector[1],
+                )
+                if not self.level.inside(next_pos):
+                    break
+
+                # Base cost for moving into the next cell.
+                current_energy -= 1
+                if current_energy < 0:
+                    break
+
+                self.path.append(
+                    BeamSegment(start=current, end=next_pos, direction=current_direction)
+                )
+
+                field = self.level.energy_fields.get(next_pos)
+                if field:
+                    current_energy -= field.drain
+                    if current_energy <= 0:
+                        break
+
+                target = self.level.targets.get(next_pos)
+                if target:
+                    self.target_energy[next_pos] += 1
+
+                mirror = self.level.mirrors.get(next_pos)
+                prism = self.level.prisms.get(next_pos)
+
+                if mirror:
+                    reflected = mirror.reflect(current_direction)
+                    if reflected is None:
+                        break
+                    current = next_pos
+                    current_direction = reflected
+                    continue
+
+                if prism and current_energy > 0:
+                    outputs = list(prism.split(current_direction))
+                    # Continue with the first output and enqueue the others.
+                    primary = outputs[0]
+                    for extra_direction in outputs[1:]:
+                        queue.append((next_pos, extra_direction, current_energy))
+                    current = next_pos
+                    current_direction = primary
+                    continue
+
+                current = next_pos
+
+    def level_complete(self) -> bool:
+        return all(
+            self.target_energy.get(position, 0) >= target.required_energy
+            for position, target in self.level.targets.items()
+        )
+
+    def required_targets_met(self) -> bool:
+        for position, target in self.level.targets.items():
+            if self.target_energy.get(position, 0) < target.required_energy:
+                return False
+        return True
+
+    def playthrough(self) -> Dict[str, object]:
+        self.propagate()
+        return {
+            "path": [segment.__dict__ for segment in self.path],
+            "targets": {
+                str(position): energy for position, energy in self.target_energy.items()
+            },
+            "metadata": self.level.metadata,
+        }
+
+
+class SolutionValidator:
+    """Validate that a solution file produces the expected completion state."""
+
+    def __init__(self, level_loader: LevelLoader, solutions_root: Path):
+        self.level_loader = level_loader
+        self.solutions_root = Path(solutions_root)
+
+    def load_solution(self, name: str) -> Dict:
+        path = self.solutions_root / f"{name}.json"
+        if not path.exists():
+            raise FileNotFoundError(path)
+        return json.loads(path.read_text())
+
+    def apply_solution(self, level: Level, solution: Dict) -> Level:
+        placements = solution.get("placements", [])
+        for placement in placements:
+            position = tuple(placement["position"])
+            if placement["type"] == "mirror":
+                level.mirrors[position] = Mirror(placement.get("orientation", "/"))
+            elif placement["type"] == "prism":
+                level.prisms[position] = Prism(spread=placement.get("spread", 1))
+            elif placement["type"] == "energy_field":
+                level.energy_fields[position] = EnergyField(drain=placement.get("drain", 1))
+            else:
+                raise ValueError(f"Unknown placement type: {placement['type']}")
+        return level
+
+    def validate(self, level_name: str, solution_name: Optional[str] = None) -> bool:
+        level = self.level_loader.load(level_name)
+        solution_data = self.load_solution(solution_name or level_name)
+        level = self.apply_solution(level, solution_data)
+        game = LaserGame(level)
+        game.propagate()
+        expected_targets = solution_data.get("expected_targets", {})
+        for key, expected in expected_targets.items():
+            position = tuple(int(v) for v in key.strip("() ").split(","))
+            if game.target_energy.get(position, 0) != expected:
+                return False
+        return game.required_targets_met()

--- a/laser_game/levels/level_intro.json
+++ b/laser_game/levels/level_intro.json
@@ -1,0 +1,12 @@
+{
+  "name": "Intro Reflect",
+  "difficulty": "Easy",
+  "width": 6,
+  "height": 6,
+  "emitters": [
+    {"position": [0, 3], "direction": "EAST", "energy": 10}
+  ],
+  "targets": [
+    {"position": [4, 1], "required_energy": 1, "label": "North Node"}
+  ]
+}

--- a/laser_game/levels/level_prismatics.json
+++ b/laser_game/levels/level_prismatics.json
@@ -1,0 +1,24 @@
+{
+  "name": "Prism Dance",
+  "difficulty": "Medium",
+  "width": 8,
+  "height": 8,
+  "emitters": [
+    {"position": [0, 4], "direction": "EAST", "energy": 12}
+  ],
+  "targets": [
+    {"position": [6, 4], "required_energy": 1, "label": "East Core"},
+    {"position": [4, 2], "required_energy": 1, "label": "North Anchor"},
+    {"position": [4, 6], "required_energy": 1, "label": "South Anchor"}
+  ],
+  "prisms": [
+    {"position": [3, 4], "spread": 1}
+  ],
+  "mirrors": [
+    {"position": [4, 3], "orientation": "\\"},
+    {"position": [4, 5], "orientation": "/"}
+  ],
+  "energy_fields": [
+    {"position": [5, 4], "drain": 1, "color": "magenta"}
+  ]
+}

--- a/laser_game/solutions/level_intro.json
+++ b/laser_game/solutions/level_intro.json
@@ -1,0 +1,9 @@
+{
+  "placements": [
+    {"type": "mirror", "position": [3, 3], "orientation": "/"},
+    {"type": "mirror", "position": [3, 1], "orientation": "/"}
+  ],
+  "expected_targets": {
+    "(4, 1)": 1
+  }
+}

--- a/laser_game/solutions/level_prismatics.json
+++ b/laser_game/solutions/level_prismatics.json
@@ -1,0 +1,11 @@
+{
+  "placements": [
+    {"type": "mirror", "position": [3, 2], "orientation": "/"},
+    {"type": "mirror", "position": [3, 6], "orientation": "\\"}
+  ],
+  "expected_targets": {
+    "(6, 4)": 1,
+    "(4, 2)": 1,
+    "(4, 6)": 1
+  }
+}

--- a/laser_game/tests/test_gameplay.py
+++ b/laser_game/tests/test_gameplay.py
@@ -1,0 +1,60 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from laser_game.game import (
+    Direction,
+    LaserEmitter,
+    LaserGame,
+    Level,
+    LevelLoader,
+    Mirror,
+    SolutionValidator,
+    Target,
+)
+
+
+def fixture_path(*parts: str) -> Path:
+    return Path(__file__).resolve().parents[1].joinpath(*parts)
+
+
+def test_mirror_reflection_turns_beam():
+    level = Level(name="Reflection", difficulty="Easy", width=5, height=5)
+    level.emitters.append(LaserEmitter(position=(0, 2), direction=Direction.EAST, energy=8))
+    level.mirrors[(2, 2)] = Mirror("/")
+    level.targets[(2, 0)] = Target(required_energy=1)
+
+    game = LaserGame(level)
+    game.propagate()
+
+    assert game.target_energy[(2, 0)] == 1
+    assert game.required_targets_met()
+
+
+def test_level_intro_solution_completes():
+    level_root = fixture_path("levels")
+    loader = LevelLoader(level_root)
+    level = loader.load("level_intro")
+
+    solution_path = fixture_path("solutions", "level_intro.json")
+    solution_data = json.loads(solution_path.read_text())
+
+    validator = SolutionValidator(loader, fixture_path("solutions"))
+    level = validator.apply_solution(level, solution_data)
+
+    game = LaserGame(level)
+    game.propagate()
+
+    assert game.level_complete()
+    assert game.target_energy[(4, 1)] == 1
+
+
+def test_solution_validator_detects_expected_targets():
+    loader = LevelLoader(fixture_path("levels"))
+    validator = SolutionValidator(loader, fixture_path("solutions"))
+
+    assert validator.validate("level_prismatics")


### PR DESCRIPTION
## Summary
- add a new `laser_game` package with the core simulation engine, level loader, and solution validator
- include JSON level definitions, reference solutions, SVG assets, and a console demo for quick verification
- cover reflections, level completion, and solution validation with automated tests

## Testing
- pytest
- python -m laser_game.demo

------
https://chatgpt.com/codex/tasks/task_e_68dffbe595088321ad51c9262c92d869