### PR TITLE
Add UI bootstrap docs and smoke tests

### DIFF
--- a/laser_game/tests/test_ui_main.py
+++ b/laser_game/tests/test_ui_main.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from laser_game.ui.main import (
+    ASSET_ENV_VAR,
+    LEVEL_ENV_VAR,
+    UIDirectories,
+    main,
+    resolve_directories,
+)
+
+
+def test_resolve_directories_returns_package_defaults():
+    directories = resolve_directories()
+
+    assert isinstance(directories, UIDirectories)
+    assert directories.asset_root.exists()
+    assert directories.level_root.exists()
+
+
+def test_resolve_directories_honours_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    asset_dir = tmp_path / "assets"
+    level_dir = tmp_path / "levels"
+    asset_dir.mkdir()
+    level_dir.mkdir()
+
+    monkeypatch.setenv(ASSET_ENV_VAR, str(asset_dir))
+    monkeypatch.setenv(LEVEL_ENV_VAR, str(level_dir))
+
+    directories = resolve_directories()
+
+    assert directories.asset_root == asset_dir
+    assert directories.level_root == level_dir
+
+
+def test_resolve_directories_errors_on_missing_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    asset_dir = tmp_path / "does_not_exist"
+    level_dir = tmp_path / "missing_levels"
+
+    monkeypatch.setenv(ASSET_ENV_VAR, str(asset_dir))
+    monkeypatch.setenv(LEVEL_ENV_VAR, str(level_dir))
+
+    with pytest.raises(FileNotFoundError):
+        resolve_directories()
+
+
+def test_main_prints_message(capsys: pytest.CaptureFixture[str]):
+    directories = main()
+    output = capsys.readouterr().out
+
+    assert "Laser Game UI bootstrap" in output
+    assert str(directories.asset_root) in output
+    assert str(directories.level_root) in output

--- a/laser_game/ui/__init__.py
+++ b/laser_game/ui/__init__.py
@@ -1,0 +1,17 @@
+"""User interface helpers for the Laser Game package."""
+
+from .main import (
+    ASSET_ENV_VAR,
+    LEVEL_ENV_VAR,
+    UIDirectories,
+    main,
+    resolve_directories,
+)
+
+__all__ = [
+    "ASSET_ENV_VAR",
+    "LEVEL_ENV_VAR",
+    "UIDirectories",
+    "main",
+    "resolve_directories",
+]

--- a/laser_game/ui/main.py
+++ b/laser_game/ui/main.py
@@ -1,0 +1,76 @@
+"""Entry point helpers for the optional Laser Game UI."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+ASSET_ENV_VAR = "LASER_GAME_ASSET_ROOT"
+LEVEL_ENV_VAR = "LASER_GAME_LEVEL_ROOT"
+
+
+@dataclass(frozen=True)
+class UIDirectories:
+    """Bundle with resolved directories required by the UI."""
+
+    asset_root: Path
+    level_root: Path
+
+
+def _default_asset_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "assets"
+
+
+def _default_level_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "levels"
+
+
+def _read_directory(env_var: str, fallback: Path) -> Path:
+    value = os.environ.get(env_var)
+    if value:
+        return Path(value).expanduser()
+    return fallback
+
+
+def resolve_directories(check_exists: bool = True) -> UIDirectories:
+    """Resolve UI directories using environment variables.
+
+    Parameters
+    ----------
+    check_exists:
+        When *True*, raise :class:`FileNotFoundError` if a resolved directory does
+        not exist on disk. Disable this in contexts where you want to inspect the
+        chosen paths without touching the filesystem.
+    """
+
+    asset_root = _read_directory(ASSET_ENV_VAR, _default_asset_root())
+    level_root = _read_directory(LEVEL_ENV_VAR, _default_level_root())
+
+    if check_exists:
+        missing = [path for path in (asset_root, level_root) if not path.exists()]
+        if missing:
+            missing_str = ", ".join(str(path) for path in missing)
+            raise FileNotFoundError(
+                f"Required UI resource directories do not exist: {missing_str}"
+            )
+
+    return UIDirectories(asset_root=asset_root, level_root=level_root)
+
+
+def main() -> UIDirectories:
+    """Return resolved directories and print a short bootstrap message."""
+
+    directories = resolve_directories()
+    message = (
+        "Laser Game UI bootstrap\n"
+        f"  assets: {directories.asset_root}\n"
+        f"  levels: {directories.level_root}\n"
+        "Set the environment variables to point to custom directories if needed."
+    )
+    print(message)
+    return directories
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation entry point
+    main()


### PR DESCRIPTION
## Summary
- document UI startup flow, environment variables, and contribution guidelines in the README
- add a minimal UI bootstrap module that resolves asset and level directories
- create pytest-based smoke tests for the UI bootstrap helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0014235008321998a52716b6eff20